### PR TITLE
Update breaking tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 
 Explode one-line address strings using Golang. 
 
-This package uses the [Google Maps API](https://console.developers.google.com/apis/credentials) to geocode the address. Don't forget to set your `GOOGLE_MAPS_API_KEY` environment variable.
+This package uses the [Google Maps API](https://console.developers.google.com/apis/credentials) to geocode the address.
+Specifically you will require the [Geocoding API](https://console.developers.google.com/apis/library/geocoding-backend.googleapis.com)
+enabled to translate address strings to detailed address objects.
+
+Don't forget to set your `GOOGLE_MAPS_API_KEY` environment variable.
 
 Installation
 -----------------

--- a/abode_test.go
+++ b/abode_test.go
@@ -72,8 +72,8 @@ func TestExplodeInternationalAddress(t *testing.T) {
 	country := "New Zealand"
 	countryCode := "NZ"
 	zip := "2014"
-	lat := -36.8991018
-	lng := 174.9338525
+	lat := -36.8990751
+	lng := 174.9334851
 	formatted := "1/4 Abercrombie Street, Howick, Auckland 2014, New Zealand"
 
 	expected := &Address{


### PR DESCRIPTION
The geolocation for the "international" address test has changed; updating so tests can continue to pass.

Also clarifies API requirements due to Google API updates.